### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@
 ## Download
   <div align="center">
 
-[<img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="Get it on IzzyOnDroid" height="80">](https://apt.izzysoft.de/fdroid/index/apk/com.bnyro.wallpaper)
-[<img src="https://raw.githubusercontent.com/vadret/android/master/assets/get-github.png" alt="Get it on GitHub" height="80">](https://github.com/bnyro/WallYou/releases)
+[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/packages/com.bnyro.wallpaper/)
+[<img src="https://raw.githubusercontent.com/vadret/android/master/assets/get-github.png" alt="Get it on GitHub" height="80">](https://github.com/bnyro/WallYou/releases/latest)
 
 </div>
 


### PR DESCRIPTION
Hi,

This small PR adds a button to get your app on F-Droid and removes the one leading to IzzyOnDroid repo, as your app is now in the official repo. You can later add a button for Google Play the same way :
`[<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png"
      alt="Get it on Google Play"
      height="80">]()`

It also adds a link to get the latest APK from the Releases Section.

You can now eventually add the [fdroid](https://github.com/topics/fdroid) and/or [f-droid](https://github.com/topics/f-droid) tags that will appear on the right side of the repo.