### PR TITLE
feat: option to select custom subreddit

### DIFF
--- a/app/src/main/java/com/bnyro/wallpaper/api/Api.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/api/Api.kt
@@ -6,8 +6,10 @@ import com.bnyro.wallpaper.util.Preferences
 abstract class Api {
     abstract val name: String
     abstract val baseUrl: String
-    abstract val filters: Map<String, List<String>>
-    abstract val supportsTags: Boolean
+    open val filters: Map<String, List<String>> = mapOf()
+    open val supportsTags: Boolean = false
+
+    private val tagsKey get() = name + "tags"
 
     abstract suspend fun getWallpapers(page: Int): List<Wallpaper>
 
@@ -22,16 +24,16 @@ abstract class Api {
     }
 
     fun getQuery(key: String): String {
-        return getPref(key, filters[key]?.firstOrNull() ?: "")
+        return getPref(key, filters[key]?.firstOrNull().orEmpty())
     }
 
     fun getTags(): List<String> {
-        return getPref(this.name + "tags", "sunset,portrait,display").split(",").filter {
+        return getPref(tagsKey, "sunset,portrait,display").split(",").filter {
             it.isNotBlank()
         }
     }
 
     fun setTags(tags: List<String>) {
-        setPref(this.name + "tags", tags.joinToString(","))
+        setPref(tagsKey, tags.joinToString(","))
     }
 }

--- a/app/src/main/java/com/bnyro/wallpaper/api/CommunityApi.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/api/CommunityApi.kt
@@ -1,0 +1,15 @@
+package com.bnyro.wallpaper.api
+
+abstract class CommunityApi : Api() {
+
+    abstract val defaultCommunityName: String
+    private val communityKey get() = name + "community"
+
+    fun setCommunityName(name: String) {
+        setPref(communityKey, name)
+    }
+
+    fun getCommunityName(): String {
+        return getPref(communityKey, defaultCommunityName)
+    }
+}

--- a/app/src/main/java/com/bnyro/wallpaper/api/bi/BiApi.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/api/bi/BiApi.kt
@@ -7,8 +7,6 @@ import com.bnyro.wallpaper.util.RetrofitBuilder
 class BiApi() : Api() {
     override val name: String = "Bing"
     override val baseUrl: String = "https://www.bing.com"
-    override val filters: Map<String, List<String>> = mapOf()
-    override val supportsTags: Boolean = false
 
     val api = RetrofitBuilder.create(baseUrl, Bing::class.java)
 

--- a/app/src/main/java/com/bnyro/wallpaper/api/mi/MiApi.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/api/mi/MiApi.kt
@@ -31,7 +31,6 @@ class MiApi : Api() {
             "News"
         )
     )
-    override val supportsTags = false
 
     private val api = RetrofitBuilder.create(baseUrl, Carousel::class.java)
 

--- a/app/src/main/java/com/bnyro/wallpaper/api/ow/OwApi.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/api/ow/OwApi.kt
@@ -11,7 +11,6 @@ class OwApi() : Api() {
     override val filters: Map<String, List<String>> = mapOf(
         "style" to listOf("all", "light", "dark")
     )
-    override val supportsTags: Boolean = false
 
     private val api = RetrofitBuilder.create(baseUrl, OWalls::class.java)
     private val resultsPerPage = 20

--- a/app/src/main/java/com/bnyro/wallpaper/api/ps/PsApi.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/api/ps/PsApi.kt
@@ -7,8 +7,6 @@ import com.bnyro.wallpaper.util.RetrofitBuilder
 class PsApi : Api() {
     override val name: String = "Picsum"
     override val baseUrl: String = "https://picsum.photos"
-    override val filters: Map<String, List<String>> = mapOf()
-    override val supportsTags: Boolean = false
 
     private val api = RetrofitBuilder.create(baseUrl, Picsum::class.java)
 

--- a/app/src/main/java/com/bnyro/wallpaper/api/re/ReApi.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/api/re/ReApi.kt
@@ -1,26 +1,26 @@
 package com.bnyro.wallpaper.api.re
 
-import com.bnyro.wallpaper.api.Api
+import com.bnyro.wallpaper.api.CommunityApi
 import com.bnyro.wallpaper.db.obj.Wallpaper
 import com.bnyro.wallpaper.util.RetrofitBuilder
 
-class ReApi : Api() {
+class ReApi : CommunityApi() {
     override val name = "Reddit"
     override val baseUrl = "https://www.reddit.com/"
-    override val filters: Map<String, List<String>> = mapOf()
-    override val supportsTags: Boolean = false
 
     val api = RetrofitBuilder.create(baseUrl, Reddit::class.java)
 
-    private val subreddit = "wallpaper"
-    private val sort = "top"
-    private val time = "week"
+    override val defaultCommunityName: String = "r/wallpaper"
+
+    private val sort = "top" // TODO: move to filter dialog by overriding [tags]
+    private val time = "week" // TODO: move to filter dialog by overriding [tags]
     private val imageRegex = Regex("^.+\\.(jpg|jpeg|png|webp)\$")
 
     override suspend fun getWallpapers(page: Int): List<Wallpaper> {
         if (page != 1) return emptyList() // TODO: Pagination
 
-        return api.getRedditData(subreddit, sort, time).data?.children?.filter {
+        val communityName = getCommunityName().replaceFirst("r/", "")
+        return api.getRedditData(communityName, sort, time).data?.children?.filter {
             it.childdata.url?.matches(imageRegex) == true
         }?.map {
             with(it.childdata) {

--- a/app/src/main/java/com/bnyro/wallpaper/ui/pages/WallpaperPage.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/ui/pages/WallpaperPage.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.bnyro.wallpaper.api.CommunityApi
 import com.bnyro.wallpaper.db.obj.Wallpaper
 import com.bnyro.wallpaper.ui.components.ShimmerGrid
 import com.bnyro.wallpaper.ui.components.WallpaperGrid
@@ -99,7 +100,10 @@ fun WallpaperPage(
                 )
             }
 
-            if (viewModel.api.filters.isNotEmpty() || viewModel.api.supportsTags) {
+            if (viewModel.api.filters.isNotEmpty() ||
+                viewModel.api.supportsTags ||
+                viewModel.api is CommunityApi
+            ) {
                 FloatingActionButton(
                     modifier = Modifier
                         .padding(horizontal = 10.dp),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="info">Info</string>
     <string name="filter">Filter</string>
     <string name="add">Add</string>
+    <string name="community_name">Community name</string>
     <!-- Info Dialog -->
     <string name="author">Author</string>
     <string name="resolution">Resolution</string>


### PR DESCRIPTION
As described in https://github.com/you-apps/WallYou/pull/119#pullrequestreview-1581063072, this adds the possibility to set a custom subreddit for wallpapers instead of using `r/wallpaper`.

I also plan to add Lemmy support, e.g. for https://lemm.ee/c/artporn@lemm.ee and https://lemm.ee/c/apocalypticart@feddit.de, so we can re-use the same new option in the filter dialog for that.