### PR TITLE
fix: Low res wallpaper loading

### DIFF
--- a/app/src/main/java/com/bnyro/wallpaper/util/ImageHelper.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/util/ImageHelper.kt
@@ -88,9 +88,9 @@ object ImageHelper {
     }
 
     fun getLocalImage(context: Context, imagePath: Uri): Bitmap? {
-        return context.contentResolver.openInputStream(imagePath)?.use { stream ->
-            val exifInterface = ExifInterface(stream)
-            val bitmap = exifInterface.thumbnailBitmap ?: return null
+        return context.contentResolver.openFileDescriptor(imagePath, "r")?.use {
+            val bitmap = BitmapFactory.decodeFileDescriptor(it.fileDescriptor) ?: return null
+            val exifInterface = ExifInterface(it.fileDescriptor) // This will change fileDescriptor position
             rotateBitmap(bitmap, exifInterface)
         }
     }


### PR DESCRIPTION
This might fix #127 

I couldn't figure out a way a way to test this.

I think this bug was caused by the change to using the Exif thumbnail instead of the full-sized bitmap [here](https://github.com/you-apps/WallYou/commit/61c14a36e8557babc78158aab10f93cdfcc3166d).

I had to use a `FileDescriptor` instead of an `InputStream` because the input stream can't be used more than once (AFAIK).