### PR TITLE
reduce minimum grid size

### DIFF
--- a/app/src/main/java/com/bnyro/wallpaper/ui/components/ShimmerGrid.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/ui/components/ShimmerGrid.kt
@@ -16,7 +16,7 @@ import com.bnyro.wallpaper.ext.shimmer
 @Composable
 fun ShimmerGrid() {
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(170.dp),
+        columns = GridCells.Adaptive(MIN_GRID_ITEM_SIZE.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(8.dp)

--- a/app/src/main/java/com/bnyro/wallpaper/ui/components/WallpaperGrid.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/ui/components/WallpaperGrid.kt
@@ -64,7 +64,7 @@ fun WallpaperGrid(
     val shape = RoundedCornerShape(10.dp)
 
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(170.dp),
+        columns = GridCells.Adaptive(MIN_GRID_ITEM_SIZE.dp),
         state = listState,
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -148,3 +148,5 @@ fun WallpaperGrid(
         if (scrollEnded) onScrollEnd.invoke()
     }
 }
+
+const val MIN_GRID_ITEM_SIZE = 150


### PR DESCRIPTION
on Samsung S25 grid was showing up as full size pics and it was blurry. this pr fixes it

before
![Screenshot_20260121_192521_Wall You](https://github.com/user-attachments/assets/85149ee4-9c44-4b0c-a069-702c70584fe8)

after
![Screenshot_20260121_192447_Wall You](https://github.com/user-attachments/assets/3f2ddf51-dfdf-415b-82d8-5a56ddfdc6df)
