### PR TITLE
Fixed lemmy wallpapers not loading due to NPE.

### DIFF
--- a/wallpaper-apis/src/main/java/net/youapps/wallpaper_apis/le/LemmyApi.kt
+++ b/wallpaper-apis/src/main/java/net/youapps/wallpaper_apis/le/LemmyApi.kt
@@ -42,7 +42,7 @@ class LemmyApi : WallpaperApi() {
         return api.getWallpapers(
             page = page,
             communityName = communityName ?: throw IllegalArgumentException("no community name specified"),
-            sort = selectedFilters["tags"]!!,
+            sort = selectedFilters["sort"]!!,
             type = selectedFilters["type"]!!
         ).posts.filter {
             !it.post.thumbnailUrl.isNullOrEmpty()


### PR DESCRIPTION
Fixed wallpapers from Lemmy not being shown due to a NullPointerException.

For some reason I am not seeing this issue with the release apk. I only see this issue when trying to run the project from android studio.

<img width="270" height="600" alt="Screenshot of the issue" src="https://github.com/user-attachments/assets/fe3a4f98-9766-4969-ae30-4dc34bb91f1b" />