### PR TITLE
Fix crash when zoom-cropping images taller than the screen

### DIFF
--- a/app/src/main/java/com/bnyro/wallpaper/util/WallpaperHelper.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/util/WallpaperHelper.kt
@@ -111,7 +111,7 @@ object WallpaperHelper {
 
         var (newWidth, newHeight) = bitmap.width to bitmap.height
         if (bitmapRatio > screenRatio) {
-            newHeight = (scaleRatio * bitmap.height).toInt()
+            newHeight = (bitmap.height / scaleRatio).toInt()
         } else {
             newWidth = (scaleRatio * bitmap.width).toInt()
         }


### PR DESCRIPTION
## Problem

`WallpaperHelper.getZoomedBitmap` (used by the default **ZOOM** resize mode) crashes for any image whose aspect ratio is taller than the screen's:

```
java.lang.IllegalArgumentException: y must be >= 0
    at android.graphics.Bitmap.createBitmap(Bitmap.java:994)
    at com.bnyro.wallpaper.util.WallpaperHelper.getZoomedBitmap(WallpaperHelper.kt:121)
    at com.bnyro.wallpaper.util.WallpaperHelper.resizeBitmapByPreference(WallpaperHelper.kt:91)
```

## Root cause

The ratios are `height / width`, and `scaleRatio = bitmapRatio / screenRatio`. In the `bitmapRatio > screenRatio` branch (image taller than the screen), `scaleRatio > 1`, so

```kotlin
newHeight = (scaleRatio * bitmap.height).toInt()   // larger than bitmap.height
```

produces a crop *taller* than the source. `gapY = (bitmap.height - newHeight) / 2` is then negative, and `Bitmap.createBitmap(bitmap, gapX, gapY, newWidth, newHeight)` rejects the negative `y`.

The purpose of this branch is to **shrink** the height to match the screen's aspect ratio, so the factor must be `< 1`. The `else` branch is already correct: there `scaleRatio < 1`, and multiplying the width shrinks it as intended.

## Fix

Divide by `scaleRatio` instead of multiplying, so `newHeight < bitmap.height` and the crop always stays inside the source:

```kotlin
newHeight = (bitmap.height / scaleRatio).toInt()
```

This equals `bitmap.width * screenRatio` — the height that matches the screen's aspect ratio at full width.

## Impact

- Affects **both** the automatic wallpaper changer and manually setting a wallpaper, since both go through `resizeBitmapByPreference` → `getZoomedBitmap`.
- Only triggers in ZOOM mode (the default) for images taller than the screen's aspect ratio (e.g. tall portrait wallpapers), so it surfaces intermittently rather than on every image.

## Example

Screen 1080×2340 (ratio 2.167), image 1000×3000 (ratio 3.0):

| | newHeight | gapY | result |
|---|---|---|---|
| before | `(3.0/2.167) × 3000 = 4153` | `-576` | crash |
| after | `3000 / 1.385 = 2167` | `416` | crop 1000×2167 (ratio 2.167) ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
