### PR TITLE
Fix height calculation for bitmap scaling

### DIFF
--- a/app/src/main/java/com/bnyro/wallpaper/util/WallpaperHelper.kt
+++ b/app/src/main/java/com/bnyro/wallpaper/util/WallpaperHelper.kt
@@ -111,7 +111,7 @@ object WallpaperHelper {
 
         var (newWidth, newHeight) = bitmap.width to bitmap.height
         if (bitmapRatio > screenRatio) {
-            newHeight = (scaleRatio * bitmap.height).toInt()
+            newHeight = (bitmap.height / scaleRatio).toInt()
         } else {
             newWidth = (scaleRatio * bitmap.width).toInt()
         }


### PR DESCRIPTION
Simple one line fix. 

When `bitmapRatio` is bigger, the image is taller than phone screen, so `newHeight` should be smaller than `bitmap.height`.

Otherwise in line 120, `gapY` is negative, and an exception occurs down the line.
